### PR TITLE
Git use LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+gradlew text eol=lf


### PR DESCRIPTION
## Summary

- force `.sh` files and `gradlew` to use LF line endings

## Why

On Windows checkouts with `core.autocrlf=true`, these Linux container scripts are converted to CRLF. Their shebangs can then fail when the scripts run inside the Linux image.

## Validation

- verified `start.sh` and `gradlew` are checked out with zero CRLF line endings when `core.autocrlf=true`
- ran `git diff --check`
