### PR TITLE
Update zen to v1.1.30-beta.3 and enable realtime updates via SSE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: build
 # Download zen : 
 .PHONY: download
 download: clean
-	curl -L -O https://github.com/AikidoSec/firewall-java/releases/download/v1.1.30-beta.2/zen.zip
+	curl -L -O https://github.com/AikidoSec/firewall-java/releases/download/v1.1.30-beta.3/zen.zip
 	unzip zen.zip -d zen_by_aikido
 	rm zen.zip
 

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,9 @@
 app = 'zen-demo-java'
 primary_region = 'ams'
 
+[env]
+  AIKIDO_FEATURE_SSE = "true"
+
 [metrics]
   port = 9400
   path = "/metrics"


### PR DESCRIPTION
Bumps the bundled Zen agent to v1.1.30-beta.3 and turns on `AIKIDO_FEATURE_SSE` via `fly.toml` `[env]`, replacing the ad-hoc Fly secret set for an earlier manual test.